### PR TITLE
Protect admin area and switch store to computing theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Tienda Online – Versión preliminar (Entrega 1 · DSY1104)
 
-Sitio web estático hecho con HTML5 + CSS externo + JavaScript vanilla. Cumple con navegación pública, render dinámico de productos, carrito persistente en `localStorage` y un panel administrativo simulado (CRUD en `localStorage`) con restricciones básicas por rol.
+Sitio web estático hecho con HTML5 + CSS externo + JavaScript vanilla. Cumple con navegación pública, render dinámico de productos de computación, carrito persistente en `localStorage` y un panel administrativo simulado (CRUD en `localStorage`) con restricciones básicas por rol.
+
+**Credenciales:** para acceder al panel administrador use `admin@tienda.com` / `admin123`.
+Los registros realizados en `registro.html` se guardan automáticamente como usuarios de tipo "Cliente".
 
 ## Cómo ejecutar
 - Opción sencilla: abre `index.html` con doble clic en tu navegador.
@@ -36,7 +39,7 @@ Sitio web estático hecho con HTML5 + CSS externo + JavaScript vanilla. Cumple c
   - Mini-cart en el header; sección de carrito en `productos.html`.
   - Reglas: cantidades ≥1, sin NaN, totales redondeados.
 - Validaciones (JS puro, mensajes en contexto)
-  - Login: correo (máx 100 y dominio permitido), contraseña (4–10).
+  - Login: requiere las credenciales del administrador (`admin@tienda.com` / `admin123`).
   - Contacto: nombre (req, máx 100), correo (máx 100 + dominio), comentario (req, máx 500).
   - Registro: nombre, correo (dominios permitidos), pass y confirmación.
   - Admin/Productos: código(min 3), nombre(≤100), desc(≤500), precio(≥0), stock(≥0 entero), stock crítico(opcional ≥0), categoría(select req). Aviso visual si `stock ≤ stockCritico`.
@@ -44,7 +47,7 @@ Sitio web estático hecho con HTML5 + CSS externo + JavaScript vanilla. Cumple c
   - Helpers implementados: `esCorreoValidoDominio`, `esLargoEntre`, `maxLongitud`, `esEnteroNoNegativo`, `esDecimalNoNegativo`, `validarRUT`, `anexarErrores`, `wireValidaciones`.
 - Admin simulado (sin backend)
   - `localStorage` claves: `productos`, `usuarios`, `tipoUsuario` (rol activo).
-  - Productos: listar/crear/editar/eliminar con persistencia en `localStorage`.
+  - Productos: listar/crear/editar/eliminar, re-stock rápido y creación rápida en `productos.html` con persistencia en `localStorage`.
   - Usuarios: listar/crear/editar/eliminar con persistencia en `localStorage`.
   - Roles: selector en header admin; si “Vendedor” oculta “Nuevo Usuario” y “Eliminar Usuario”. “Cliente” es solo visual (no debería usar admin).
 

--- a/admin/productos.html
+++ b/admin/productos.html
@@ -32,6 +32,13 @@
     </aside>
     <main class="admin-main">
       <h1>Productos</h1>
+      <form id="form-producto-rapido" class="form-inline">
+        <input name="codigo" placeholder="Código" required>
+        <input name="nombre" placeholder="Nombre" required>
+        <input name="precio" type="number" min="0" placeholder="Precio" required>
+        <input name="stock" type="number" min="0" placeholder="Stock" required>
+        <button class="btn" type="submit">Agregar</button>
+      </form>
       <table class="tabla">
         <thead>
           <tr>

--- a/js/data.js
+++ b/js/data.js
@@ -1,19 +1,41 @@
 // Datos semilla y catálogos
 // Categorías
-const CATEGORIAS = ["Accesorios", "Electrónica", "Hogar", "Ropa"];
+const CATEGORIAS = ["Componentes", "Periféricos", "Almacenamiento", "Computadores"];
 
 // Productos (id único)
 const PRODUCTOS_SEMILLA = [
-  { id: "p1", codigo: "A100", nombre: "Audífonos", descripcion: "Inalámbricos", precio: 19990, stock: 15, stockCritico: 3, categoria: "Electrónica", imagen: "img/audifonos.jpg" },
-  { id: "p2", codigo: "H200", nombre: "Hervidor", descripcion: "1.7L acero", precio: 24990, stock: 8, categoria: "Hogar", imagen: "img/hervidor.jpg" },
-  { id: "p3", codigo: "R300", nombre: "Polera básica", descripcion: "Algodón", precio: 9990, stock: 30, categoria: "Ropa", imagen: "img/polera.jpg" },
-  { id: "p4", codigo: "AC10", nombre: "Cable USB-C", descripcion: "1m", precio: 3990, stock: 50, categoria: "Accesorios", imagen: "img/cable.jpg" }
+  { id: "p1", codigo: "CPU01", nombre: "Procesador Ryzen 5", descripcion: "6 núcleos 3.9GHz", precio: 199990, stock: 10, categoria: "Componentes", imagen: "img/placeholder.png" },
+  { id: "p2", codigo: "SSD02", nombre: "SSD 1TB", descripcion: "NVMe", precio: 109990, stock: 15, categoria: "Almacenamiento", imagen: "img/placeholder.png" },
+  { id: "p3", codigo: "NB03", nombre: "Notebook Lenovo", descripcion: "14\" 8GB RAM", precio: 449990, stock: 7, categoria: "Computadores", imagen: "img/placeholder.png" },
+  { id: "p4", codigo: "MS04", nombre: "Mouse Gamer", descripcion: "RGB 16000 DPI", precio: 29990, stock: 25, categoria: "Periféricos", imagen: "img/placeholder.png" }
 ];
 
 // Usuarios (admin simulado)
 const USUARIOS_SEMILLA = [
-  { id: "u1", run: "19011022K", nombre: "Ana", apellidos: "Pérez Soto", correo: "ana@duoc.cl", tipoUsuario: "Administrador", region: "Los Lagos", comuna: "Puerto Montt", direccion: "Av. X 123" },
-  { id: "u2", run: "18222333K", nombre: "Luis", apellidos: "García Mora", correo: "luis@gmail.com", tipoUsuario: "Vendedor", region: "RM", comuna: "Santiago", direccion: "Calle Y 456" }
+  {
+    id: "u1",
+    run: "19011022K",
+    nombre: "Ana",
+    apellidos: "Pérez Soto",
+    correo: "admin@tienda.com",
+    password: "admin123",
+    tipoUsuario: "Administrador",
+    region: "Los Lagos",
+    comuna: "Puerto Montt",
+    direccion: "Av. X 123"
+  },
+  {
+    id: "u2",
+    run: "18222333K",
+    nombre: "Luis",
+    apellidos: "García Mora",
+    correo: "luis@gmail.com",
+    password: "vend123",
+    tipoUsuario: "Vendedor",
+    region: "RM",
+    comuna: "Santiago",
+    direccion: "Calle Y 456"
+  }
 ];
 
 // Regiones/Comunas


### PR DESCRIPTION
## Summary
- Restrict admin pages to a single administrator user and redirect unauthenticated visitors
- Update seed data and README to reflect a computing-focused store with admin credentials
- Add quick product creation and restock actions in admin panel
- Persist registered users as clients and validate login credentials from stored users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc0fa3e78832f9a39e4af82a6791d